### PR TITLE
Add warning when a request on the root is served

### DIFF
--- a/router.js
+++ b/router.js
@@ -13,6 +13,7 @@ const unaWrapper = getLnClient()
 
 fastify.get('/', async (request, reply) => {
   // TODO Render html instead of JSON
+  console.warn('Unexpected request to root. When using a proxy, make sure the URL path is forwarded.')
   const words = bech32.toWords(Buffer.from(_lnurlpUrl, 'utf8'))
   return {
     lnurlp: bech32.encode('lnurl', words, 1023),


### PR DESCRIPTION
I would assume the root url is never called on Ligess. This is likely the result of a proxy misconfiguration.