### PR TITLE
Warning when LND_REST is not using https

### DIFF
--- a/startup.js
+++ b/startup.js
@@ -22,6 +22,9 @@ const startup = () => {
 const _lndCheck = () => {
   const requiredKeys = ['LIGESS_LND_REST', 'LIGESS_LND_MACAROON']
   checkKeys(requiredKeys)
+  if (!process.env.LIGESS_LND_REST.startsWith('https:')) {
+    console.error('Env variable LIGESS_LND_REST only supports https protocol')
+  } 
 }
 
 const _eclairCheck = () => {


### PR DESCRIPTION
This might add in troubleshooting, as the resulting error when using http doesn't make it clear where to find the problem. Not sure if the same holds for eclair.

See https://twitter.com/mutatrum/status/1517151394888708096